### PR TITLE
Handle albums without ASCII alphanums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.13.2] 2022-04-03
+
+### Fixed
+
+* Fixed importing of officially purchased Bandcamp tracks which have **Visit {label_url}** in their `COMMENT` field (at least for FLAC files) when the album name does not contain a single ASCII alphanumeric character. We here use the album name to guess the release url, and in this case the plugin has previously been failing to take into account this edge case and failed the import process immediately.
+
+[0.13.2]: https://github.com/snejus/beetcamp/releases/tag/0.13.2
+
 ## [0.13.1] 2022-04-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beetcamp"
-version = "0.13.1"
+version = "0.13.2"
 description = "Bandcamp autotagger source for beets (http://beets.io)."
 authors = ["Šarūnas Nejus <snejus@pm.me>"]
 readme = "README.md"

--- a/tests/test_real_queries.py
+++ b/tests/test_real_queries.py
@@ -73,17 +73,13 @@ def test_candidates(ep):
 
 
 def test_singleton_item_candidates(single_track_release):
-    """Normally it takes ~10s to search and find a match."""
+    """Our test singleton should be the first search result."""
     expected = single_track_release.singleton
     pl = BandcampPlugin()
 
-    candidates = pl.item_candidates(Item(), expected.artist, expected.title)
-    for track in candidates:
-        if track.title == expected.title:
-            assert vars(track) == vars(expected)
-            break
-    else:
-        pytest.fail("Expected singleton was not returned.")
+    track = next(pl.item_candidates(Item(), expected.artist, expected.title))
+    assert track
+    assert vars(track) == vars(expected)
 
 
 @pytest.mark.parametrize("method", ["album_for_id", "track_for_id"])

--- a/tests/test_real_queries.py
+++ b/tests/test_real_queries.py
@@ -86,20 +86,6 @@ def test_singleton_item_candidates(single_track_release):
         pytest.fail("Expected singleton was not returned.")
 
 
-def test_singleton_cheat_mode(single_track_release):
-    """In the cheat mode it should take around 1-2s to match a singleton."""
-    expected = single_track_release.singleton
-    pl = BandcampPlugin()
-
-    item = Item()
-    item.comments = "Visit " + expected.artist_id
-    item.title = expected.artist + " - " + expected.title
-
-    candidates = pl.item_candidates(item, expected.artist, item.title)
-    track = next(candidates)
-    assert vars(track) == vars(expected)
-
-
 @pytest.mark.parametrize("method", ["album_for_id", "track_for_id"])
 def test_handle_non_bandcamp_url(method):
     """The plugin should not break if a non-bandcamp URL is presented."""


### PR DESCRIPTION
### Fixed

* Fixed importing of officially purchased Bandcamp tracks which have **Visit {label_url}** in their `COMMENT` field (at least for FLAC files) when the album name does not contain a single ASCII alphanumeric character. We here use the album name to guess the release url, and in this case the plugin has previously been failing to take into account this edge case and failed the import process immediately.

[0.13.2]: https://github.com/snejus/beetcamp/releases/tag/0.13.2
