### PR TITLE
[BUG] Fix regex bug with type of url

### DIFF
--- a/beetsplug/bandcamp/_search.py
+++ b/beetsplug/bandcamp/_search.py
@@ -26,7 +26,7 @@ RELEASE_PATTERNS = [
     re.compile(r"\n\s+by " + _f("artist")),
     re.compile(r"\n\s+released " + _f("date")),
     re.compile(r"\n\s+(?P<tracks>\d+) tracks"),
-    re.compile(r"(?P<url>https://(?P<label>(?!bandcamp)[^.]+)[.](?!bcbits)[\w/.-]+)"),
+    re.compile(r"(?P<url>https://(?:bandcamp\.)?(?P<label>(?!bandcamp|com)[^.]+)[.](?!bcbits)[\w/.-]+)"),
 ]
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,8 @@
 """Tests for searching functionality."""
+import re
+
 import pytest
-from beetsplug.bandcamp._search import parse_and_sort_results
+from beetsplug.bandcamp._search import RELEASE_PATTERNS, parse_and_sort_results
 
 # simplified version of the search result HTML block
 HTML_ITEM = """
@@ -64,3 +66,13 @@ def test_search_prioritises_best_matches(search_data):
         html, **{**search_data, "name": "Specific Release"}
     )
     assert results == expected_results
+
+
+@pytest.mark.parametrize(('test_url', 'expected_label'), (
+    ('https://bandcamp.materiacollective.com/track/the-illusionary-dance', 'materiacollective'),
+    ('https://finderskeepersrecords.bandcamp.com/track/illusional-frieze', 'finderskeepersrecords'),
+))
+def test_search_matches(test_url, expected_label):
+    test_matches = RELEASE_PATTERNS[-1].match(test_url)
+    assert test_matches.group('url') == test_url
+    assert test_matches.group('label') == expected_label


### PR DESCRIPTION
I encountered this error while loading a large library into beets, which crashes with the stacktrace below. It seems that the regex for the URL doesn't recognise that there are apparently two types of Bandcamp URL returned. The regex has been fixed in this PR and I've added a test illustrating the two types of URLs and how the test fixes them.

```
Traceback (most recent call last):
  File "/usr/bin/beet", line 33, in <module>
    sys.exit(load_entry_point('beets==1.6.0', 'console_scripts', 'beet')())
  File "/usr/share/beets/beets/ui/__init__.py", line 1285, in main
    _raw_main(args)
  File "/usr/share/beets/beets/ui/__init__.py", line 1272, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/usr/share/beets/beets/ui/commands.py", line 973, in import_func
    import_files(lib, paths, query)
  File "/usr/share/beets/beets/ui/commands.py", line 943, in import_files
    session.run()
  File "/usr/share/beets/beets/importer.py", line 340, in run
    pl.run_parallel(QUEUE_SIZE)
  File "/usr/share/beets/beets/util/pipeline.py", line 446, in run_parallel
    raise exc_info[1].with_traceback(exc_info[2])
  File "/usr/share/beets/beets/util/pipeline.py", line 311, in run
    out = self.coro.send(msg)
  File "/usr/share/beets/beets/util/pipeline.py", line 193, in coro
    func(*(args + (task,)))
  File "/usr/share/beets/beets/importer.py", line 1376, in lookup_candidates
    task.lookup_candidates()
  File "/usr/share/beets/beets/importer.py", line 913, in lookup_candidates
    prop = autotag.tag_item(self.item, search_ids=self.search_ids)
  File "/usr/share/beets/beets/autotag/match.py", line 518, in tag_item
    for track_info in hooks.item_candidates(item, search_artist, search_title):
  File "/usr/share/beets/beets/plugins.py", line 573, in decorated
    for v in generator(*args, **kwargs):
  File "/usr/share/beets/beets/autotag/hooks.py", line 648, in item_candidates
    yield from plugins.item_candidates(item, artist, title)
  File "/usr/share/beets/beets/plugins.py", line 392, in item_candidates
    yield from plugin.item_candidates(item, artist, title)
  File "/home/serene/.local/lib/python3.10/site-packages/beetsplug/bandcamp/__init__.py", line 235, in item_candidates
    yield from filter(truth, map(self.get_track_info, results))
KeyError: 'url'
```