### PR TITLE
Fix regex bug with lookahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## UPCOMING
+
+### Fixed
+
+* (#36) Fix bug with some URLs
+
 ## [0.16.0] 2022-08-19
 
 [0.16.0]: https://github.com/snejus/beetcamp/releases/tag/0.16.0

--- a/beetsplug/bandcamp/_search.py
+++ b/beetsplug/bandcamp/_search.py
@@ -26,10 +26,8 @@ RELEASE_PATTERNS = [
     re.compile(r"\n\s+by " + _f("artist")),
     re.compile(r"\n\s+released " + _f("date")),
     re.compile(r"\n\s+(?P<tracks>\d+) tracks"),
-]
-URL_PATTERNS = [
-    re.compile(r"(?P<url>https://(?P<label>(?!bandcamp\.)[^.]+)\.(?!bcbits)[\w/.-]+)"),  # label-first pattern
     re.compile(r"(?P<url>https://bandcamp\.(?P<label>[^.]+)\.(?!bcbits)[\w/.-]+)"),  # label-second pattern
+    re.compile(r"(?P<url>https://(?P<label>(?!bandcamp\.)[^.]+)\.(?!bcbits)[\w/.-]+)"),  # label-first pattern
 ]
 
 
@@ -61,11 +59,6 @@ def get_matches(text: str) -> JSONDict:
     for pat in RELEASE_PATTERNS:
         for m in pat.finditer(text):
             result.update(m.groupdict())
-    for url_pat in URL_PATTERNS:
-        for m in url_pat.finditer(text):
-            if m:
-                result.update(m.groupdict())
-                break
     if "type" in result:
         result["type"] = result["type"].lower()
     if "date" in result:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,6 @@
 """Tests for searching functionality."""
 import pytest
-from beetsplug.bandcamp._search import URL_PATTERNS, get_matches, parse_and_sort_results
+from beetsplug.bandcamp._search import get_matches, parse_and_sort_results
 
 # simplified version of the search result HTML block
 HTML_ITEM = """

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,6 @@
 """Tests for searching functionality."""
 import pytest
-from beetsplug.bandcamp._search import RELEASE_PATTERNS, parse_and_sort_results
+from beetsplug.bandcamp._search import URL_PATTERNS, get_matches, parse_and_sort_results
 
 # simplified version of the search result HTML block
 HTML_ITEM = """
@@ -70,17 +70,16 @@ def test_search_prioritises_best_matches(search_data):
 @pytest.mark.parametrize(
     ("test_url", "expected_label"),
     (
-        (
-            "https://bandcamp.materiacollective.com/track/the-illusionary-dance",
-            "materiacollective",
-        ),
-        (
-            "https://finderskeepersrecords.bandcamp.com/track/illusional-frieze",
-            "finderskeepersrecords",
-        ),
+        ("https://bandcamp.materiacollective.com/track/the-illusionary-dance", "materiacollective", ),
+        ("https://finderskeepersrecords.bandcamp.com/track/illusional-frieze", "finderskeepersrecords", ),
+        ("https://compiladoaspen.bandcamp.com/track/kiss-from-a-rose", "compiladoaspen", ),
+        ("https://comtruise.bandcamp.com/track/karova-digital-bonus-3", "comtruise",),
+        ("https://bandofholyjoy.bandcamp.com/track/lost-in-the-night", "bandofholyjoy",),
+        ("https://bandcampcomp.bandcamp.com/track/everything-everything-in-birdsong-acoustic", "bandcampcomp",),
+        ("https://bandcamp.bandcamp.com/track/warm-2", "bandcamp",),
     ),
 )
 def test_search_matches(test_url, expected_label):
-    test_matches = RELEASE_PATTERNS[-1].match(test_url)
-    assert test_matches.group("url") == test_url
-    assert test_matches.group("label") == expected_label
+    result = get_matches(test_url)
+    assert result["url"] == test_url
+    assert result["label"] == expected_label


### PR DESCRIPTION
My fix last time added an additional bug because of course it did. The lookahead present in the regex automatically disqualified any label or group beginning with the string 'com'. This commit fixes that, and I've included several additional tests that illustrate this. The same issue was present beforehand with names beginning with 'bandcamp' but that's much rarer than names beginning with 'com' so I guess that it never came up.