### PR TITLE
Do not exclude albums that have bundle in the name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.17.1] 2023-05-20
+
+[0.17.1]: https://github.com/snejus/beetcamp/releases/tag/0.17.1
+
+### Fixed
+
+* (#44) fix an issue with bundle media formats exclusion logic which would wrongly exclude
+  albums that have **bundle** in their names
+
+
 ## [0.17.0] 2023-05-20
 
 [0.17.0]: https://github.com/snejus/beetcamp/releases/tag/0.17.0

--- a/beetsplug/bandcamp/_helpers.py
+++ b/beetsplug/bandcamp/_helpers.py
@@ -306,7 +306,7 @@ class Helpers:
                 # musicReleaseFormat format is given or it is a USB
                 and ("musicReleaseFormat" in obj or obj["type_id"] == 5)
                 # it is not a vinyl bundle
-                and "bundle" not in obj["name"].lower()
+                and not (obj["item_type"] == "p" and "bundle" in obj["name"].lower())
             )
 
         formats = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beetcamp"
-version = "0.17.0"
+version = "0.17.1"
 description = "Bandcamp autotagger source for beets (http://beets.io)."
 authors = ["Šarūnas Nejus <snejus@pm.me>"]
 readme = "README.md"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -80,10 +80,14 @@ def test_unpack_props(vinyl_format):
     assert {"some_id", "item_type"} < set(result)
 
 
-def test_bundles_get_excluded(bundle_format, vinyl_format):
-    result = Helpers.get_media_formats([bundle_format, vinyl_format])
+def test_bundles_get_excluded(bundle_format, digital_format):
+    album_name = "Everyone Bundle"
+    bundle_album_name_format = {**digital_format, "name": album_name}
+
+    result = Helpers.get_media_formats([bundle_format, bundle_album_name_format])
+
     assert len(result) == 1
-    assert result[0].name == "Vinyl"
+    assert result[0].title == album_name
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Fixed

* (#44) fix an issue with bundle media formats exclusion logic which would wrongly exclude
  albums that have **bundle** in their names
