### PR TITLE
add: fb missing artist

### DIFF
--- a/beetsplug/bandcamp/__init__.py
+++ b/beetsplug/bandcamp/__init__.py
@@ -218,9 +218,11 @@ class BandcampPlugin(BandcampRequestsHandler, plugins.BeetsPlugin):
 
         if album == "":
             search = {
-                "query": artist + " - " + item.title,
-                "artist": artist,
-                "label": label,
+                "query": item.artist + " - " + item.title
+                if item.artist != ""
+                else item.title,
+                "artist": item.artist,
+                "label": item.label,
                 "search_type": "",
             }
         else:

--- a/beetsplug/bandcamp/__init__.py
+++ b/beetsplug/bandcamp/__init__.py
@@ -216,22 +216,19 @@ class BandcampPlugin(BandcampRequestsHandler, plugins.BeetsPlugin):
         if "various" in artist.lower():
             artist = ""
 
-        if album == "":
-            search = {
-                "query": item.artist + " - " + item.title
-                if item.artist != ""
-                else item.title,
-                "artist": item.artist,
-                "label": item.label,
-                "search_type": "",
-            }
+        if album:
+            query = album
+            search_type = "a"
         else:
-            search = {
-                "query": album,
-                "artist": artist,
-                "label": label,
-                "search_type": "a",
-            }
+            query = " - ".join(filter(None, [artist, item.title]))
+            search_type = ""
+
+        search = {
+            "query": query,
+            "artist": artist,
+            "label": label,
+            "search_type": search_type,
+        }
 
         results = map(itemgetter("url"), self._search(search))
         yield from chain.from_iterable(filter(None, map(self.get_album_info, results)))


### PR DESCRIPTION
Just found that my alterations to the search (#68) break if the artist is empty (bandcamp search can't handle ' - title' syntax in search). This fixes the issue. I did not include a changelog entry as this feature has not been released yet and is already present in the log.