### PR TITLE
Small fixes in album name parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Fixed
+
+- (#93) Do not assume that the first part of the album such as **Neon White OST 1 - The
+  Wicked Heart** is an artist if it contains a reference to a sound track.
+
 ## [0.24.2] 2026-04-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ### Fixed
 
-- (#93) Do not assume that the first part of the album such as **Neon White OST 1 - The
-  Wicked Heart** is an artist if it contains a reference to a sound track.
+- `album`: 
+  - (#93) Do not assume that the first part of the album such as **Neon White OST 1 - The
+    Wicked Heart** is an artist if it contains a reference to a sound track.
+  - Do not parse remix name as a catalognum in track titles such as **What Is Love (Funk
+    Tribu Edit 2K23)**
 
 ## [0.24.2] 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Unreleased
 
+## [0.24.3] 2026-04-17
+
 ### Fixed
 
-- `album`: 
+- `album`:
   - (#93) Do not assume that the first part of the album such as **Neon White OST 1 - The
     Wicked Heart** is an artist if it contains a reference to a sound track.
   - Do not parse remix name as a catalognum in track titles such as **What Is Love (Funk
@@ -1462,4 +1464,5 @@ Thanks @arogl for reporting each of the above!
 [0.23.0]: https://github.com/snejus/beetcamp/releases/tag/0.23.0
 [0.24.0]: https://github.com/snejus/beetcamp/releases/tag/0.24.0
 [0.24.1]: https://github.com/snejus/beetcamp/releases/tag/0.24.1
-[0.24.2]: https://github.com/snejus/beetcamp/releases/tag/0.24.1
+[0.24.2]: https://github.com/snejus/beetcamp/releases/tag/0.24.2
+[0.24.3]: https://github.com/snejus/beetcamp/releases/tag/0.24.3

--- a/beetcamp/album_name.py
+++ b/beetcamp/album_name.py
@@ -50,6 +50,9 @@ class AlbumName:
         re.IGNORECASE,
     )
     COMPILATION_IN_TITLE = cached_patternprop(r"compilation|best of|anniversary", re.I)
+    SOUNDTRACK_IN_TITLE = cached_patternprop(
+        r"\b(?:o\.?s\.?t\.?|original soundtrack|soundtrack|score)\b", re.I
+    )
     YEAR_RANGE = cached_patternprop(r"20[12]\d - 20[12]\d")
 
     original: str
@@ -249,6 +252,8 @@ class AlbumName:
         if len(split := Track.DELIM_NOT_INSIDE_PARENS.split(album)) > 1:
             left, right = map(str.strip, split[:2])
             if ":" in left and self.SERIES.search(right):
+                return None
+            if self.SOUNDTRACK_IN_TITLE.search(left):
                 return None
             return left
 

--- a/beetcamp/catalognum.py
+++ b/beetcamp/catalognum.py
@@ -133,6 +133,7 @@ class Catalognum:
             CONSTRAINT_TEMPLATE.format(
                 r"""
                 (?!(?i:part|va|sample))
+                (?![^])]*\b(?i:edit|remix|remaster)\b)
                 # at least one upper letter, ends with a digit
                 ([^])]*[A-Z][^])]*[0-9]+)
                 """

--- a/beetcamp/metaguru.py
+++ b/beetcamp/metaguru.py
@@ -183,7 +183,7 @@ class Metaguru(Helpers):
 
         This property calculates the lead artist based on the original album artist,
         label, and track track collaborators. Since this property gets required before
-        track artists are available, it uses the pinciple of elimination to find the
+        track artists are available, it uses the principle of elimination to find the
         albumartist candidate.
         """
         aartist = self.original_albumartist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "beetcamp"
-version = "0.24.2"
+version = "0.24.3"
 description = "Bandcamp autotagger source for beets (http://beets.io)."
 authors = [{ name = "Šarūnas Nejus", email = "snejus@pm.me" }]
 readme = "README.md"

--- a/tests/test_album_name.py
+++ b/tests/test_album_name.py
@@ -145,6 +145,8 @@ def test_standardize_series(original, in_desc, expected):
     "original, expected",
     [
         ("Satie: Complete Piano Works - Volume 10", None),
+        ("Neon White OST 2 - The Burn That Cures", None),
+        ('Spencer Parker - "Remember"', "Spencer Parker"),
     ],
 )
 def test_find_artist(original, expected):

--- a/tests/test_catalognum.py
+++ b/tests/test_catalognum.py
@@ -75,6 +75,7 @@ from beetcamp.metaguru import Metaguru
         ("", "", "CA12 ok", "", "CA12"),
         ("", "", "this CA12 not", "", ""),
         ("AE-MJ-001.1", "", "", "", "AE-MJ-001.1"),
+        ("What Is Love (Funk Tribu Edit 2K23)", "", "", "Funk Tribu", ""),
     ],
 )
 def test_parse_catalognum(json_meta, vinyl_format, label, expected, beets_config):

--- a/tests/test_metaguru.py
+++ b/tests/test_metaguru.py
@@ -127,3 +127,20 @@ def test_prefers_root_artist_when_track_artists_look_like_title_fragments(
     assert guru.albumartist == "carrie z"
     assert [t.artist for t in guru.tracks] == ["carrie z", "carrie z", "carrie z"]
     assert [t.title for t in guru.tracks] == expected_titles
+
+
+def test_preliminary_albumartist_ignores_soundtrack_title_prefix(json_meta, beets_config):
+    json_meta["name"] = "Neon White OST 2 - The Burn That Cures"
+    json_meta["byArtist"]["name"] = "Machine Girl"
+    json_meta["publisher"]["name"] = "Machine Girl"
+    json_meta["track"]["itemListElement"] = [
+        {"position": idx, "item": {"@id": f"track{idx}", "name": name}}
+        for idx, name in enumerate(
+            ["Sermon", "Peace of Mind", "Heavenly Delight"],
+            start=1,
+        )
+    ]
+
+    guru = Metaguru(json_meta, beets_config)
+
+    assert guru.preliminary_albumartist == "Machine Girl"


### PR DESCRIPTION
### Fixed

- `album`: 
  - (#93) Do not assume that the first part of the album such as **Neon White OST 1 - The
    Wicked Heart** is an artist if it contains a reference to a sound track.
  - Do not parse remix name as a catalognum in track titles such as **What Is Love (Funk
    Tribu Edit 2K23)**

Fixes: #93 