### PR TITLE
fix(search): use bandcamp's public JSON API instead of scraping /search

### DIFF
--- a/beetcamp/http.py
+++ b/beetcamp/http.py
@@ -2,6 +2,7 @@ import atexit
 import re
 from functools import cache, partial
 from html import unescape
+from typing import Any
 
 import beets
 import httpx
@@ -29,6 +30,18 @@ def http_get_text(url: str) -> str:
     response.raise_for_status()
 
     return unescape(response.text)
+
+
+def http_post_json(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the JSON response to a POST request.
+
+    Deliberately not cached, unlike `http_get_text`: dict payloads are unhashable,
+    and search results should not be pinned for the lifetime of the process.
+    """
+    response = _client.post(url, json=payload, follow_redirects=True)
+    response.raise_for_status()
+
+    return response.json()
 
 
 def urlify(pretty_string: str) -> str:

--- a/beetcamp/search.py
+++ b/beetcamp/search.py
@@ -1,19 +1,28 @@
 """Module with bandcamp search functionality."""
 from __future__ import annotations
 
+import logging
 import re
 from difflib import SequenceMatcher
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, urlsplit
 
-from .http import http_get_text
+from .http import http_get_text, http_post_json
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 JSONDict = dict[str, Any]
 SEARCH_URL = "https://bandcamp.com/search?page={}&q={}"
+# The JSON endpoint bandcamp's own search box uses. The HTML page at SEARCH_URL is behind a
+# JavaScript "Client Challenge" which a scraper cannot solve, so it returns a challenge stub
+# with no results and searching silently yields nothing. See #99.
+SEARCH_API_URL = "https://bandcamp.com/api/bcsearch_public_api/1/autocomplete_elastic"
+# Map the API's terse item types onto the words the HTML search page used.
+ITEM_TYPES = {"a": "album", "t": "track", "b": "band", "f": "fan"}
+
+log = logging.getLogger(__name__)
 
 
 def _f(field: str) -> str:
@@ -85,16 +94,71 @@ def parse_and_sort_results(html: str, **kwargs: str) -> list[JSONDict]:
     `kwargs` contains field and value pairs we compare the results with. Usually,
     this has 'label', 'artist' and 'name' ('title' or 'album') fields.
     """
-    results: list[JSONDict] = []
-    for block in html.split("searchresult data-search")[1:]:
-        res = get_matches(block)
+    return sort_results(
+        [get_matches(block) for block in html.split("searchresult data-search")[1:]],
+        **kwargs,
+    )
+
+
+def sort_results(results: list[JSONDict], **kwargs: str) -> list[JSONDict]:
+    """Sort results by their similarity to the queried fields and index them.
+
+    Shared by both search backends so ranking does not depend on where the rows came from.
+    """
+    for res in results:
         similarities = [
             get_similarity(query, res.get(field, "")) for field, query in kwargs.items()
         ]
         res["similarity"] = round(sum(similarities) / len(similarities), 3)
-        results.append(res)
     results = sorted(results, key=itemgetter("similarity"), reverse=True)
     return [{"index": i + 1, **r} for i, r in enumerate(results)]
+
+
+def api_results(query: str, search_type: str = "") -> list[JSONDict]:
+    """Return search results from bandcamp's public JSON search API.
+
+    Rows are mapped onto the same keys the HTML parser produced, so callers and the
+    similarity scoring do not need to know which backend answered. `album`, `date` and
+    `tracks` are not exposed by this endpoint; they are only used for scoring and display,
+    and every read of them is a `.get(field, "")`, so their absence is harmless.
+    """
+    payload = {
+        "fan_id": None,
+        "full_page": False,
+        "search_filter": search_type,
+        "search_text": query,
+    }
+    data = http_post_json(SEARCH_API_URL, payload)
+    # The API answers HTTP 200 with an error body rather than a failure status, and an
+    # unrecognised shape would otherwise yield an empty list -- i.e. exactly the silent
+    # "no results" that hid the broken HTML scrape. Raise so the caller warns and falls back.
+    if data.get("error"):
+        raise ValueError(
+            f"bandcamp search API error: {data.get('error_message', 'unknown')}"
+        )
+    if "auto" not in data:
+        raise ValueError(f"unexpected bandcamp search API response: {sorted(data)[:5]}")
+
+    results = []
+    for item in (data.get("auto") or {}).get("results") or []:
+        url = item.get("item_url_path") or ""
+        if not url:
+            continue
+        res: JSONDict = {
+            "type": ITEM_TYPES.get(item.get("type", ""), item.get("type", "")),
+            "name": item.get("name") or "",
+            "artist": item.get("band_name") or "",
+            "url": url,
+            # The HTML page exposed the label as the bandcamp subdomain; derive the same.
+            "label": (urlsplit(item.get("item_url_root") or url).hostname or "").split(
+                "."
+            )[0],
+        }
+        # The API sends the *string* "None" rather than null when there are no tags.
+        if (genre := item.get("tag_names")) and genre != "None":
+            res["genre"] = genre
+        results.append(res)
+    return results
 
 
 def search_bandcamp(
@@ -109,6 +173,19 @@ def search_bandcamp(
         filter(None, [kwargs.get("artist"), kwargs.get("name")])
     )
     kwargs.setdefault("name", query)
+
+    # Prefer the JSON API: the HTML search page is behind a JavaScript "Client Challenge"
+    # that a scraper cannot solve, so it yields no results at all (#99).
+    try:
+        return sort_results(api_results(query, search_type), **kwargs)
+    except Exception:
+        # Say so. This failing quietly is what let the broken HTML scrape go unnoticed.
+        log.warning(
+            "bandcamp search API request failed, falling back to scraping the search page"
+            " (which is likely to return nothing while it is behind a client challenge)",
+            exc_info=True,
+        )
+
     url = SEARCH_URL.format(page, quote_plus(query))
     if search_type:
         url += f"&item_type={search_type}"


### PR DESCRIPTION
Fixes #99.

`bandcamp.com/search` is behind a Fastly JavaScript "Client Challenge". `parse_and_sort_results`
splits the page on `searchresult data-search`; the challenge stub contains none of those markers, so
every query returns `[]` — silently, with no error and no log line. Measured 8/8 attempts challenged;
`search_bandcamp()` returned 0 rows for every query I tried, including well-known releases:

```
album page   len=259865  challenged=False    <- direct URLs still work
search page  len=  3036  challenged=True
```

This switches search to `https://bandcamp.com/api/bcsearch_public_api/1/autocomplete_elastic`, the
JSON endpoint bandcamp's own search box uses. **It is not challenged, and it works with the existing
beets User-Agent** — I checked the beets UA, a browser UA and no UA at all and got identical results,
so there is no impersonation here; `http.py`'s client is used unchanged.

### Shape of the change

- `http_post_json()` added beside `http_get_text()`, reusing the module's existing `httpx.Client`.
  Deliberately not `@cache`d — dict payloads are unhashable and search results should not be pinned
  for the process lifetime.
- `sort_results()` factored out of `parse_and_sort_results()` so both backends share the similarity
  scoring and `index`/`similarity` keys. Ranking behaviour is unchanged.
- `api_results()` maps API rows onto the keys the HTML parser produced: `url` ← `item_url_path`,
  `artist` ← `band_name`, `type` (`a`→`album`), `label` ← the bandcamp subdomain, `genre` ←
  `tag_names` (the API sends the *string* `"None"` when empty). `album`, `date` and `tracks` are not
  exposed; they are only used for scoring and display and every read is `.get(field, "")`.
- The HTML scrape is kept as a fallback. A failure now logs a **WARNING** with a traceback instead of
  passing silently — that silence is what let this go unnoticed.
- The API answers **HTTP 200 with `{"error": true, ...}`** rather than a failure status, so that is
  detected explicitly. Without it the function would return `[]` and reproduce the exact silent
  failure this fixes. (I only found this because I tested the fallback rather than assuming it worked.)

`search_bandcamp`'s signature is unchanged: `get=` still feeds the fallback, so both callers —
`beetsplug/bandcamp` (`get=self._get`) and the CLI's positional `query` — keep working.

### Verified against the live API

```
ok  Nboj Tespo — Blessed Planet   -> southofnorthamsterdam.bandcamp.com/album/blessed-planet
ok  Overmono — Good Lies          -> overmono.bandcamp.com/album/good-lies
ok  Coby Sey — Conduit            -> cobysey.bandcamp.com/album/conduit
ok  Sarah Davachi — Two Sisters   -> sarahdavachi.bandcamp.com/album/two-sisters
ok  rows carry the HTML contract keys (url, name, artist, type, label, similarity, index)
ok  HTTP-200 error body: falls back, WARNING emitted
ok  network failure:     falls back, WARNING emitted
ok  healthy path returns results and stays quiet
```

End to end through beets, `BandcampPlugin.candidates()` for a real inbox album returns an AlbumInfo
with 10 tracks matching the 10 files on disk — where before the change it returned nothing.

### Not addressed here

Query construction is unchanged, so a release credited to several artists can still miss: a folder
tagged `Daemon, Iceboy Violet, Orlandor` does not match, while `Iceboy Violet` finds
`iceboyviolet.bandcamp.com/album/the-vanity-project` immediately. Searching the album name alone
finds it (29 hits, correct one ranked 2nd by the existing similarity sort), so a name-only retry when
the artist-qualified search comes back empty would help — but it multiplies `get_album_info()`
fetches per preview, so it seemed better left as a separate change for you to weigh.
